### PR TITLE
fix: add lacked titles

### DIFF
--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -292,7 +292,7 @@ class SVModelInfo(BaseModel):
 
     uuid: str = Field(title="モデル固有のUUID")
     variance_model: str = Field(title="variance_model.onnxをbase64エンコードした文字列")
-    embedder_model: str = Field("embedder_model.onnxをbase64エンコードした文字列")
-    decoder_model: str = Field("decoder_model.onnxをbase64エンコードした文字列")
-    metas: List[Speaker] = Field("metas.jsonをlistにしたモデルのメタ情報")
-    speaker_infos: Dict[str, SpeakerInfo] = Field("keyをspeakerInfoのUUIDとした複数のspeaker情報")
+    embedder_model: str = Field(title="embedder_model.onnxをbase64エンコードした文字列")
+    decoder_model: str = Field(title="decoder_model.onnxをbase64エンコードした文字列")
+    metas: List[Speaker] = Field(title="metas.jsonをlistにしたモデルのメタ情報")
+    speaker_infos: Dict[str, SpeakerInfo] = Field(title="keyをspeakerInfoのUUIDとした複数のspeaker情報")


### PR DESCRIPTION
## 内容
OpenAPIの自動生成ができないなと思ったら、model.pyで `title=`をつけるのを忘れていたためでした。sry :pray:

fix #1 

## その他
sharevoxの方でSVModelInfo.tsを作れたので良いと思います。

```bash
curl http://127.0.0.1:50025/openapi.json >openapi.json

$(npm bin)/openapi-generator-cli generate \
    -i openapi.json \
    -g typescript-fetch \
    -o src/openapi/ \
    --additional-properties=modelPropertyNaming=camelCase,supportsES6=true,withInterfaces=true,typescriptThreePlus=true

yarn fmt
(snip)
[main] INFO  o.o.codegen.TemplateManager - writing file /Users/deadbeef/work/sharevox/src/openapi/models/SVModelInfo.ts
```