### PR TITLE
feat: add ModelConfig into sv_model

### DIFF
--- a/run.py
+++ b/run.py
@@ -815,6 +815,8 @@ def generate_app(
         metas: List[Speakers]
             モデルのメタ情報
             metas.jsonをlistにしたもの
+        model_config: ModelConfig
+            model_config.jsonをdictにした機械学習に利用するための情報
         speaker_infos: Dict[str, SpeakerInfo]
             keyをspeakerInfoのUUIDとした複数のspeaker情報
         """

--- a/test/test_sv_models.py
+++ b/test/test_sv_models.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import TestCase
 
 from voicevox_engine.model import (
+    ModelConfig,
     Speaker,
     SpeakerInfo,
     SpeakerStyle,
@@ -60,6 +61,10 @@ class TestSVModel(TestCase):
                     version="0.0.1",
                 ),
             ],
+            model_config=ModelConfig(
+                length_regulator="gaussian",
+                start_id=1,
+            ),
             speaker_infos={
                 speaker_uuid: SpeakerInfo(
                     policy="dummy policy",
@@ -98,6 +103,7 @@ class TestSVModel(TestCase):
         # check if only the file size is more than 0,
         # because it's めんどい
         self.assertTrue(os.path.getsize(f"./test/model/{sv_model_uuid}/metas.json") > 0)
+        self.assertTrue(os.path.getsize(f"./test/model/{sv_model_uuid}/model_config.json") > 0)
 
         expected_same_files = [
             "policy.md",

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -144,6 +144,15 @@ class SpeakerInfo(BaseModel):
     style_infos: List[StyleInfo] = Field(title="スタイルの追加情報")
 
 
+class ModelConfig(BaseModel):
+    """
+    model_config.jsonをdictにした機械学習に利用するための情報
+    """
+
+    length_regulator: str = Field(title="利用するregulatorの文字列。normalもしくはgaussian")
+    start_id: int = Field(title="model番号のoffset")
+
+
 class DownloadableLibrary(BaseModel):
     """
     ダウンロード可能な音声ライブラリの情報（最新情報をwebで取得することを考慮して、ローカルの情報はない）
@@ -306,4 +315,5 @@ class SVModelInfo(BaseModel):
     embedder_model: str = Field(title="embedder_model.onnxをbase64エンコードした文字列")
     decoder_model: str = Field(title="decoder_model.onnxをbase64エンコードした文字列")
     metas: List[Speaker] = Field(title="metas.jsonをlistにしたモデルのメタ情報")
+    model_config: ModelConfig = Field(title="model_config.jsonをdictにした機械学習に利用するための情報")
     speaker_infos: Dict[str, SpeakerInfo] = Field(title="keyをspeakerInfoのUUIDとした複数のspeaker情報")

--- a/voicevox_engine/sv_model.py
+++ b/voicevox_engine/sv_model.py
@@ -64,6 +64,10 @@ def register_sv_model(
         with open(model_uuid_dir / "metas.json", "w") as f:
             json.dump([meta.json() for meta in sv_model.metas], f)
 
+        # model_config.jsonは/model/${uuid}/model_config.jsonに保存する
+        with open(model_uuid_dir / "model_config.json", "w") as f:
+            json.dump(sv_model.model_config.dict(), f)
+
         # 異常なUUIDを含んでいないか確認する
         assert len(sv_model.metas) == len(sv_model.speaker_infos)
         for meta in sv_model.metas:


### PR DESCRIPTION
## 内容
sv_modelの仕様変更に従い、新しくModelConfigを追加しました。

## Unit Test

```bash
% python3 -m pytest ./test/test_sv_models.py
======================================== test session starts ========================================
platform darwin -- Python 3.8.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /Users/deadbeef/work/sharevox_engine
plugins: anyio-3.3.4
collected 2 items                                                                                   

test/test_sv_models.py ..                                                                     [100%]

========================================= 2 passed in 0.10s =========================================
```

## その他
更新後のモデル定義が書かれたnotion
https://www.notion.so/y-chan/Engine-3ce859d733d64f08ac839eccf8c7b457