### PR TITLE
feat: overwrite when a uuid of model added newly is conflicted

### DIFF
--- a/run.py
+++ b/run.py
@@ -823,9 +823,6 @@ def generate_app(
         """
         try:
             register_sv_model(sv_model)
-        except FileExistsError:
-            traceback.print_exc()
-            raise HTTPException(status_code=409, detail="モデルのUUIDが衝突しました。")
         except Exception:
             traceback.print_exc()
             raise HTTPException(status_code=500, detail="モデルの登録に失敗しました")

--- a/voicevox_engine/sv_model.py
+++ b/voicevox_engine/sv_model.py
@@ -50,7 +50,7 @@ def register_sv_model(
         model_uuid_dir = stored_dir / "model" / sv_model.uuid
         already_exists = os.path.exists(model_uuid_dir)
         if already_exists:
-            os.rename(model_uuid_dir, model_uuid_dir + ".old")
+            os.rename(model_uuid_dir, f"{model_uuid_dir}.old")
         os.makedirs(model_uuid_dir)
 
         # variance_model, embedder_model, decoder_modelは
@@ -81,7 +81,7 @@ def register_sv_model(
             
             # 既にモデルが存在していた場合はrenameしておく
             if already_exists:
-                os.rename(speaker_info_dir, speaker_info_dir + ".old")
+                os.rename(speaker_info_dir, f"{speaker_info_dir}.old")
 
             os.makedirs(speaker_info_dir / "icons")
             os.makedirs(speaker_info_dir / "voice_samples")
@@ -123,10 +123,10 @@ def register_sv_model(
         
         # backupを削除する
         if already_exists:
-            shutil.rmtree(model_uuid_dir + ".old")
+            shutil.rmtree(f"{model_uuid_dir}.old")
             for speaker_uuid, speaker_info in sv_model.speaker_infos.items():
                 speaker_info_dir = stored_dir / "speaker_info" / speaker_uuid
-                shutil.rmtree(speaker_info_dir + ".old")
+                shutil.rmtree(f"{speaker_info_dir}.old")
 
     except Exception as e:
         # 削除時にエラーが発生しても無視する
@@ -137,8 +137,8 @@ def register_sv_model(
             )
         
         # backupからrestoreする
-        os.rename(model_uuid_dir + ".old", model_uuid_dir)
+        os.rename(f"{model_uuid_dir}.old", model_uuid_dir)
         for speaker_uuid, speaker_info in sv_model.speaker_infos.items():
             speaker_info_dir = stored_dir / "speaker_info" / speaker_uuid
-            os.rename(speaker_info_dir + ".old", speaker_info_dir)
+            os.rename(f"{speaker_info_dir}.old", speaker_info_dir)
         raise e

--- a/voicevox_engine/sv_model.py
+++ b/voicevox_engine/sv_model.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import os
-from pyexpat import model
 import shutil
 from pathlib import Path
 from typing import List

--- a/voicevox_engine/sv_model.py
+++ b/voicevox_engine/sv_model.py
@@ -80,7 +80,7 @@ def register_sv_model(
             speaker_info_dir = stored_dir / "speaker_info" / speaker_uuid
             
             # 既にモデルが存在していた場合はrenameしておく
-            if already_exists:
+            if already_exists and os.path.exists(speaker_info_dir):
                 os.rename(speaker_info_dir, f"{speaker_info_dir}.old")
 
             os.makedirs(speaker_info_dir / "icons")
@@ -126,7 +126,9 @@ def register_sv_model(
             shutil.rmtree(f"{model_uuid_dir}.old")
             for speaker_uuid, speaker_info in sv_model.speaker_infos.items():
                 speaker_info_dir = stored_dir / "speaker_info" / speaker_uuid
-                shutil.rmtree(f"{speaker_info_dir}.old")
+                # 新しく追加されるspeaker_info_dirに.oldは存在しないはずなので、exists checkをする
+                if os.path.exists(f"{speaker_info_dir}.old"):
+                    shutil.rmtree(f"{speaker_info_dir}.old")
 
     except Exception as e:
         # 削除時にエラーが発生しても無視する
@@ -140,5 +142,6 @@ def register_sv_model(
         os.rename(f"{model_uuid_dir}.old", model_uuid_dir)
         for speaker_uuid, speaker_info in sv_model.speaker_infos.items():
             speaker_info_dir = stored_dir / "speaker_info" / speaker_uuid
-            os.rename(f"{speaker_info_dir}.old", speaker_info_dir)
+            if os.path.exists(f"{speaker_info_dir}.old"):
+                os.rename(f"{speaker_info_dir}.old", speaker_info_dir)
         raise e


### PR DESCRIPTION
## 内容
従来のSV Model APIは既存モデルの上書きが禁止されていたが、このPRで上書きをするようにする

## 関連 Issue
closes #5

## スクリーンショット・動画など
- `test.svlib` と `multi.svlib` をそれぞれ2回アップロードしてエラーが起きないか検証

https://user-images.githubusercontent.com/29667656/191007736-7cf29a1c-d855-44be-8110-c60e7b3660d4.mp4


## その他
フロント側の実装は別途行われる

※重複したファイルをインストールするときに途中でインストール失敗した場合、restoreができないのが問題な気もしています
既存ファイルがあった場合はそれぞれのファイルを.origとかにrenameしてからinstallして、最後に削除するみたいな方針をとったほうが良いかもしれません